### PR TITLE
Fix for llama 3.1 models

### DIFF
--- a/app/lib/.server/llm/constants.ts
+++ b/app/lib/.server/llm/constants.ts
@@ -1,5 +1,5 @@
 // see https://docs.anthropic.com/en/docs/about-claude/models
-export const MAX_TOKENS = 8192;
+export const MAX_TOKENS = 8000;
 
 // limits the number of model responses that can be returned in a single request
 export const MAX_RESPONSE_SEGMENTS = 2;


### PR DESCRIPTION
max_tokens for llama 3.1 models must be less than or equal to 8000 but it is set to 8192. just change it to 8000 and the error is fixed.
![Screenshot 2024-10-21 192155](https://github.com/user-attachments/assets/fcf58bb8-2f80-4049-a081-fced027b9f9c)
