### PR TITLE
fix: simplify local start - remove pnpm from preview script, make it work on Windows and not fail due to bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "test:watch": "vitest",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "lint:fix": "npm run lint -- --fix",
-    "start": "sh -c '[[ \"$(uname -s)\" == *NT* ]] && wrangler pages dev  ./build/client --ip 0.0.0.0 --port 3000 || (bindings=$(./bindings.sh) && wrangler pages dev ./build/client $bindings --ip 0.0.0.0 --port 3000)'",
-    "typecheck": "tsc",
+    "start:windows": "wrangler pages dev ./build/client",
+    "start:unix": "bindings=$(./bindings.sh) && wrangler pages dev ./build/client $bindings",
+    "start": "node -e \"const { spawn } = require('child_process'); const isWindows = process.platform === 'win32'; const cmd = isWindows ? 'npm run start:windows' : 'npm run start:unix'; const child = spawn(cmd, { shell: true, stdio: 'inherit' }); child.on('exit', code => process.exit(code));\"",    "typecheck": "tsc",
     "typegen": "wrangler types",
     "preview": "npm run build && npm run start"
   },

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "test:watch": "vitest",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "lint:fix": "npm run lint -- --fix",
-    "start": "bindings=$(./bindings.sh) && wrangler pages dev ./build/client $bindings --ip 0.0.0.0 --port 3000",
+    "start": "sh -c '[[ \"$(uname -s)\" == *NT* ]] && wrangler pages dev  ./build/client --ip 0.0.0.0 --port 3000 || (bindings=$(./bindings.sh) && wrangler pages dev ./build/client $bindings --ip 0.0.0.0 --port 3000)'",
     "typecheck": "tsc",
     "typegen": "wrangler types",
-    "preview": "pnpm run build && pnpm run start"
+    "preview": "npm run build && npm run start"
   },
   "engines": {
     "node": ">=18.18.0"


### PR DESCRIPTION
This is a small 2-line change to cleanup run scripts to work better on Windows

Want to make a video on youtube of how to run Bolt.New on windows locally in the simplest way, 2 things complicate it unnecessarily. And I fix them here, its just 2 lines.

1. I removed pnpm from the preview as other commands use npm anyway and it removes one additional thing for beginners to install and use. npm is good enough for general repo.
2. I added a fallback for Windows not to use bindings. They are not used currently for local running always.

This should not break Docker part but I don't use docker so would be nice if someone who does checks
