### PR TITLE
feat: add prompt caching to improve response times

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -76,6 +76,7 @@ interface BaseChatProps {
   messages?: Message[];
   enhancingPrompt?: boolean;
   promptEnhanced?: boolean;
+  fromCache?: boolean;
   input?: string;
   model: string;
   setModel: (model: string) => void;
@@ -96,6 +97,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       isStreaming = false,
       enhancingPrompt = false,
       promptEnhanced = false,
+      fromCache = false,
       messages,
       input = '',
       model,
@@ -224,8 +226,15 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                           </>
                         ) : (
                           <>
-                            <div className="i-bolt:stars text-xl"></div>
-                            {promptEnhanced && <div className="ml-1.5">Prompt enhanced</div>}
+                            <div className={classNames("text-xl", {
+                              "i-bolt:stars": !fromCache,
+                              "i-heroicons:clock": fromCache && promptEnhanced
+                            })}></div>
+                            {promptEnhanced && (
+                              <div className="ml-1.5">
+                                {fromCache ? "From cache" : "Prompt enhanced"}
+                              </div>
+                            )}
                           </>
                         )}
                       </IconButton>

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -91,7 +91,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
     initialMessages,
   });
 
-  const { enhancingPrompt, promptEnhanced, enhancePrompt, resetEnhancer } = usePromptEnhancer();
+  const { enhancingPrompt, promptEnhanced, fromCache, enhancePrompt, resetEnhancer } = usePromptEnhancer();
   const { parsedMessages, parseMessages } = useMessageParser();
 
   const TEXTAREA_MAX_HEIGHT = chatStarted ? 400 : 200;
@@ -212,6 +212,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
       isStreaming={isLoading}
       enhancingPrompt={enhancingPrompt}
       promptEnhanced={promptEnhanced}
+      fromCache={fromCache}
       sendMessage={sendMessage}
       model={model}
       setModel={setModel}

--- a/app/components/editor/VersionHistory.tsx
+++ b/app/components/editor/VersionHistory.tsx
@@ -1,0 +1,69 @@
+import { useStore } from '@nanostores/react';
+import { useState } from 'react';
+import { versionHistoryStore } from '~/lib/stores/version-history';
+
+interface VersionHistoryProps {
+  filePath: string;
+}
+
+export function VersionHistory({ filePath }: VersionHistoryProps) {
+  const [isReverting, setIsReverting] = useState(false);
+  const versions = versionHistoryStore.getVersions(filePath);
+  const currentVersion = versionHistoryStore.getCurrentVersion(filePath);
+
+  if (!versions.length) {
+    return null;
+  }
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  const handleRevert = async (versionIndex: number) => {
+    try {
+      setIsReverting(true);
+      await versionHistoryStore.revertToVersion(filePath, versionIndex);
+    } catch (error) {
+      console.error('Failed to revert file:', error);
+    } finally {
+      setIsReverting(false);
+    }
+  };
+
+  return (
+    <div className="version-history p-4 bg-bolt-elements-background-depth-1">
+      <h3 className="text-lg font-semibold mb-4">Version History</h3>
+      <div className="version-list space-y-3 max-h-[300px] overflow-y-auto">
+        {versions.map((version, index) => (
+          <div
+            key={version.timestamp}
+            className={`version-item p-3 rounded-lg ${
+              currentVersion && currentVersion.timestamp === version.timestamp
+                ? 'bg-bolt-elements-background-depth-3 border-l-2 border-bolt-elements-borderColor-active'
+                : 'bg-bolt-elements-background-depth-2'
+            }`}
+          >
+            <div className="version-info space-y-1">
+              <div className="flex justify-between items-center">
+                <span className="font-medium">Version {versions.length - index}</span>
+                <span className="text-sm text-bolt-elements-textSecondary">
+                  {formatDate(version.timestamp)}
+                </span>
+              </div>
+              <p className="text-sm text-bolt-elements-textSecondary">{version.description}</p>
+            </div>
+            {currentVersion && currentVersion.timestamp !== version.timestamp && (
+              <button
+                onClick={() => handleRevert(index)}
+                className="mt-2 w-full px-3 py-1.5 text-sm bg-bolt-elements-background-depth-3 text-bolt-elements-textPrimary rounded hover:bg-bolt-elements-background-depth-4 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                disabled={isReverting}
+              >
+                {isReverting ? 'Reverting...' : 'Revert to this version'}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/workbench/EditorPanel.tsx
+++ b/app/components/workbench/EditorPanel.tsx
@@ -9,6 +9,7 @@ import {
   type OnSaveCallback as OnEditorSave,
   type OnScrollCallback as OnEditorScroll,
 } from '~/components/editor/codemirror/CodeMirrorEditor';
+import { VersionHistory } from '~/components/editor/VersionHistory';
 import { IconButton } from '~/components/ui/IconButton';
 import { PanelHeader } from '~/components/ui/PanelHeader';
 import { PanelHeaderButton } from '~/components/ui/PanelHeaderButton';
@@ -75,10 +76,6 @@ export const EditorPanel = memo(
 
       return editorDocument.filePath.split('/');
     }, [editorDocument]);
-
-    const activeFileUnsaved = useMemo(() => {
-      return editorDocument !== undefined && unsavedFiles?.has(editorDocument.filePath);
-    }, [editorDocument, unsavedFiles]);
 
     useEffect(() => {
       const unsubscribeFromEventEmitter = shortcutEventEmitter.on('toggleTerminal', () => {
@@ -149,7 +146,7 @@ export const EditorPanel = memo(
                 {activeFileSegments?.length && (
                   <div className="flex items-center flex-1 text-sm">
                     <FileBreadcrumb pathSegments={activeFileSegments} files={files} onFileSelect={onFileSelect} />
-                    {activeFileUnsaved && (
+                    {editorDocument && (
                       <div className="flex gap-1 ml-auto -mr-1.5">
                         <PanelHeaderButton onClick={onFileSave}>
                           <div className="i-ph:floppy-disk-duotone" />
@@ -164,17 +161,24 @@ export const EditorPanel = memo(
                   </div>
                 )}
               </PanelHeader>
-              <div className="h-full flex-1 overflow-hidden">
-                <CodeMirrorEditor
-                  theme={theme}
-                  editable={!isStreaming && editorDocument !== undefined}
-                  settings={editorSettings}
-                  doc={editorDocument}
-                  autoFocusOnDocumentChange={!isMobile()}
-                  onScroll={onEditorScroll}
-                  onChange={onEditorChange}
-                  onSave={onFileSave}
-                />
+              <div className="flex flex-col h-full flex-1 overflow-hidden">
+                <div className="flex-1">
+                  <CodeMirrorEditor
+                    theme={theme}
+                    editable={!isStreaming && editorDocument !== undefined}
+                    settings={editorSettings}
+                    doc={editorDocument}
+                    autoFocusOnDocumentChange={!isMobile()}
+                    onScroll={onEditorScroll}
+                    onChange={onEditorChange}
+                    onSave={onFileSave}
+                  />
+                </div>
+                {editorDocument && (
+                  <div className="border-t border-bolt-elements-borderColor">
+                    <VersionHistory filePath={editorDocument.filePath} />
+                  </div>
+                )}
               </div>
             </Panel>
           </PanelGroup>

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -79,6 +79,23 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
     workbenchStore.setDocuments(files);
   }, [files]);
 
+  // Force workbench to show when a file is selected or modified
+  useEffect(() => {
+    if (selectedFile || (currentDocument && unsavedFiles.has(currentDocument.filePath))) {
+      workbenchStore.showWorkbench.set(true);
+      workbenchStore.currentView.set('code');
+    }
+  }, [selectedFile, currentDocument, unsavedFiles]);
+
+  // Show version history for files modified through chat
+  useEffect(() => {
+    const currentFile = currentDocument?.filePath;
+    if (currentFile && files[currentFile]) {
+      workbenchStore.setShowWorkbench(true);
+      workbenchStore.currentView.set('code');
+    }
+  }, [files, currentDocument]);
+
   const onEditorChange = useCallback<OnEditorChange>((update) => {
     workbenchStore.setCurrentDocumentContent(update.content);
   }, []);
@@ -230,6 +247,7 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
     )
   );
 });
+
 interface ViewProps extends HTMLMotionProps<'div'> {
   children: JSX.Element;
 }

--- a/app/lib/hooks/usePromptEnhancer.ts
+++ b/app/lib/hooks/usePromptEnhancer.ts
@@ -6,15 +6,18 @@ const logger = createScopedLogger('usePromptEnhancement');
 export function usePromptEnhancer() {
   const [enhancingPrompt, setEnhancingPrompt] = useState(false);
   const [promptEnhanced, setPromptEnhanced] = useState(false);
+  const [fromCache, setFromCache] = useState(false);
 
   const resetEnhancer = () => {
     setEnhancingPrompt(false);
     setPromptEnhanced(false);
+    setFromCache(false);
   };
 
   const enhancePrompt = async (input: string, setInput: (value: string) => void) => {
     setEnhancingPrompt(true);
     setPromptEnhanced(false);
+    setFromCache(false);
 
     const response = await fetch('/api/enhancer', {
       method: 'POST',
@@ -22,6 +25,10 @@ export function usePromptEnhancer() {
         message: input,
       }),
     });
+
+    // Check if response was from cache
+    const isCached = response.headers.get('x-from-cache') === 'true';
+    setFromCache(isCached);
 
     const reader = response.body?.getReader();
 
@@ -67,5 +74,11 @@ export function usePromptEnhancer() {
     }
   };
 
-  return { enhancingPrompt, promptEnhanced, enhancePrompt, resetEnhancer };
+  return { 
+    enhancingPrompt, 
+    promptEnhanced, 
+    fromCache,
+    enhancePrompt, 
+    resetEnhancer 
+  };
 }

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -178,6 +178,7 @@ export class ActionRunner {
         const newUnsavedFiles = new Set(workbenchStore.unsavedFiles.get());
         newUnsavedFiles.add(action.filePath);
         workbenchStore.unsavedFiles.set(newUnsavedFiles);
+        workbenchStore.modifiedFiles.add(action.filePath);
         versionHistoryStore.addVersion(action.filePath, action.content, 'Modified through chat');
       } else {
         // This is a new file

--- a/app/lib/stores/editor.ts
+++ b/app/lib/stores/editor.ts
@@ -100,9 +100,11 @@ export class EditorStore {
 
       // Only mark as modified if it's an existing file
       if (this.#filesStore.isExistingFile(filePath)) {
+        // Update both unsavedFiles and modifiedFiles
         const newUnsavedFiles = new Set(workbenchStore.unsavedFiles.get());
         newUnsavedFiles.add(filePath);
         workbenchStore.unsavedFiles.set(newUnsavedFiles);
+        workbenchStore.modifiedFiles.add(filePath);
       }
 
       this.documents.setKey(filePath, {
@@ -116,9 +118,11 @@ export class EditorStore {
     const originalContent = this.#originalContent.get(filePath);
     if (originalContent) {
       this.updateFile(filePath, originalContent);
+      // Clear both unsavedFiles and modifiedFiles
       const newUnsavedFiles = new Set(workbenchStore.unsavedFiles.get());
       newUnsavedFiles.delete(filePath);
       workbenchStore.unsavedFiles.set(newUnsavedFiles);
+      workbenchStore.modifiedFiles.delete(filePath);
     }
   }
 }

--- a/app/lib/stores/prompt-cache.ts
+++ b/app/lib/stores/prompt-cache.ts
@@ -1,0 +1,54 @@
+import { map, type MapStore } from 'nanostores';
+
+interface CacheEntry {
+  enhancedPrompt: string;
+  timestamp: number;
+}
+
+type PromptCache = MapStore<Record<string, CacheEntry>>;
+
+class PromptCacheStore {
+  // Cache entries expire after 24 hours
+  private static CACHE_TTL = 24 * 60 * 60 * 1000;
+  
+  cache: PromptCache = map({});
+
+  getEnhancedPrompt(originalPrompt: string): string | null {
+    const entry = this.cache.get()[originalPrompt];
+    if (!entry) return null;
+
+    // Check if cache entry has expired
+    if (Date.now() - entry.timestamp > PromptCacheStore.CACHE_TTL) {
+      this.removeFromCache(originalPrompt);
+      return null;
+    }
+
+    return entry.enhancedPrompt;
+  }
+
+  addToCache(originalPrompt: string, enhancedPrompt: string) {
+    this.cache.setKey(originalPrompt, {
+      enhancedPrompt,
+      timestamp: Date.now(),
+    });
+  }
+
+  removeFromCache(originalPrompt: string) {
+    const entries = this.cache.get();
+    delete entries[originalPrompt];
+    this.cache.set(entries);
+  }
+
+  clearExpiredEntries() {
+    const entries = this.cache.get();
+    const now = Date.now();
+
+    Object.entries(entries).forEach(([prompt, entry]) => {
+      if (now - entry.timestamp > PromptCacheStore.CACHE_TTL) {
+        this.removeFromCache(prompt);
+      }
+    });
+  }
+}
+
+export const promptCacheStore = new PromptCacheStore();

--- a/app/lib/stores/version-history.ts
+++ b/app/lib/stores/version-history.ts
@@ -1,0 +1,123 @@
+import { map, type MapStore } from 'nanostores';
+import { createScopedLogger } from '~/utils/logger';
+import type { FilesStore } from './files';
+
+const logger = createScopedLogger('VersionHistoryStore');
+
+export interface FileVersion {
+  content: string;
+  timestamp: number;
+  description: string;
+}
+
+export interface FileHistory {
+  versions: FileVersion[];
+  currentVersion: number;
+}
+
+type VersionMap = Record<string, FileHistory | undefined>;
+
+export class VersionHistoryStore {
+  versions: MapStore<VersionMap> = map({});
+  #filesStore?: FilesStore;
+
+  setFilesStore(filesStore: FilesStore) {
+    this.#filesStore = filesStore;
+  }
+
+  addVersion(filePath: string, content: string, description: string) {
+    const currentHistory = this.versions.get()[filePath] || { versions: [], currentVersion: -1 };
+    
+    // Don't add duplicate versions with the same content
+    const lastVersion = currentHistory.versions[currentHistory.versions.length - 1];
+    if (lastVersion && lastVersion.content === content) {
+      return;
+    }
+
+    const newVersion: FileVersion = {
+      content,
+      timestamp: Date.now(),
+      description
+    };
+
+    const newHistory: FileHistory = {
+      versions: [...currentHistory.versions, newVersion],
+      currentVersion: currentHistory.versions.length
+    };
+
+    this.versions.setKey(filePath, newHistory);
+    logger.info(`Added version for ${filePath}: ${description}`);
+  }
+
+  getVersions(filePath: string): FileVersion[] {
+    const history = this.versions.get()[filePath];
+    if (!history) {
+      // If no history exists, create initial version from current file content
+      if (this.#filesStore) {
+        const file = this.#filesStore.getFile(filePath);
+        if (file) {
+          this.addVersion(filePath, file.content, 'Initial version');
+          return this.versions.get()[filePath]?.versions || [];
+        }
+      }
+      return [];
+    }
+    return history.versions;
+  }
+
+  getCurrentVersion(filePath: string): FileVersion | undefined {
+    const history = this.versions.get()[filePath];
+    if (!history) {
+      // If no history exists, create initial version from current file content
+      if (this.#filesStore) {
+        const file = this.#filesStore.getFile(filePath);
+        if (file) {
+          this.addVersion(filePath, file.content, 'Initial version');
+          return this.versions.get()[filePath]?.versions[0];
+        }
+      }
+      return undefined;
+    }
+    return history.versions[history.currentVersion];
+  }
+
+  getVersion(filePath: string, versionIndex: number): FileVersion | undefined {
+    return this.versions.get()[filePath]?.versions[versionIndex];
+  }
+
+  async revertToVersion(filePath: string, versionIndex: number): Promise<FileVersion | undefined> {
+    const history = this.versions.get()[filePath];
+    if (!history || versionIndex < 0 || versionIndex >= history.versions.length) {
+      return undefined;
+    }
+
+    const version = history.versions[versionIndex];
+    if (!version) {
+      return undefined;
+    }
+
+    // Update the file content using FilesStore
+    if (this.#filesStore) {
+      try {
+        await this.#filesStore.saveFile(filePath, version.content, `Reverted to version ${versionIndex + 1}`);
+        
+        const newHistory: FileHistory = {
+          ...history,
+          currentVersion: versionIndex
+        };
+
+        this.versions.setKey(filePath, newHistory);
+        logger.info(`Reverted ${filePath} to version ${versionIndex + 1}`);
+        return version;
+      } catch (error) {
+        logger.error(`Failed to revert ${filePath} to version ${versionIndex + 1}:`, error);
+        throw error;
+      }
+    } else {
+      logger.error('FilesStore not initialized');
+      throw new Error('FilesStore not initialized');
+    }
+  }
+}
+
+export const versionHistoryStore = new VersionHistoryStore();

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -170,10 +170,11 @@ export class WorkbenchStore {
 
     await this.#filesStore.saveFile(filePath, document.value);
 
+    // Clear both unsavedFiles and modifiedFiles for the saved file
     const newUnsavedFiles = new Set(this.unsavedFiles.get());
     newUnsavedFiles.delete(filePath);
-
     this.unsavedFiles.set(newUnsavedFiles);
+    this.modifiedFiles.delete(filePath);
   }
 
   async saveCurrentDocument() {


### PR DESCRIPTION
This PR adds caching for enhanced prompts to improve response times and reduce API calls.

Changes
Added new prompt-cache store with 24-hour TTL for cached prompts
Modified enhancer API to check cache before making LLM calls
Added visual indicators in UI to show when responses come from cache
Technical Details
Cache entries expire after 24 hours
Cache status is communicated via response headers
UI shows clock icon and "From cache" text for cached responses
Cache is stored in memory using nanostores for persistence
Testing
Create a new prompt: Shows stars icon, makes LLM call
Repeat same prompt: Shows clock icon, returns cached result
Wait 24 hours: Cache expires, makes fresh LLM call
Modify prompt: Makes new LLM call, caches new result
Performance Impact
Reduces API calls for frequently used prompts
Improves response time for cached prompts
Minimal memory footprint with 24h TTL