### PR TITLE
fix: gemini create model error

### DIFF
--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -41,9 +41,9 @@ export function getMistralModel(apiKey: string, model: string) {
 }
 
 export function getGoogleModel(apiKey: string, model: string) {
-  const google = createGoogleGenerativeAI(
+  const google = createGoogleGenerativeAI({
     apiKey,
-  );
+  });
 
   return google(model);
 }


### PR DESCRIPTION
Fixes the arguments passed to createGoogleGenerativeAI. It should be an object.