### PR TITLE
feat: set numCtx = 32768 for Ollama models

### DIFF
--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -58,7 +58,10 @@ export function getGroqModel(apiKey: string, model: string) {
 }
 
 export function getOllamaModel(baseURL: string, model: string) {
-  let Ollama = ollama(model);
+  let Ollama = ollama(model, {
+    numCtx: 32768,
+  });
+
   Ollama.config.baseURL = `${baseURL}/api`;
   return Ollama;
 }


### PR DESCRIPTION
Looks like [ollama-ai-provider](https://github.com/sgomez/ollama-ai-provider/blob/main/packages/ollama/src/ollama-chat-settings.ts#L189) support setting context length via setting `numCtx`.

We could probably expose it via ENV  if needed

https://github.com/user-attachments/assets/d0e975b7-c658-4116-a8c1-d6585656934a

