### PR TITLE
feat: docker - Update bindings.sh to Use Environment Variables Directly

### DIFF
--- a/bindings.sh
+++ b/bindings.sh
@@ -2,15 +2,31 @@
 
 bindings=""
 
-while IFS= read -r line || [ -n "$line" ]; do
-  if [[ ! "$line" =~ ^# ]] && [[ -n "$line" ]]; then
-    name=$(echo "$line" | cut -d '=' -f 1)
-    value=$(echo "$line" | cut -d '=' -f 2-)
-    value=$(echo $value | sed 's/^"\(.*\)"$/\1/')
-    bindings+="--binding ${name}=${value} "
-  fi
-done < .env.local
+# List all the environment variables you need
+keys=(
+  "GROQ_API_KEY"
+  "OPENAI_API_KEY"
+  "ANTHROPIC_API_KEY"
+  "OPEN_ROUTER_API_KEY"
+  "GOOGLE_GENERATIVE_AI_API_KEY"
+  "OLLAMA_API_BASE_URL"
+  "OPENAI_LIKE_API_BASE_URL"
+  "DEEPSEEK_API_KEY"
+  "OPENAI_LIKE_API_KEY"
+  "MISTRAL_API_KEY"
+  "XAI_API_KEY"
+  "VITE_LOG_LEVEL"
+)
 
+# Iterate over each key and retrieve its value from the environment
+for key in "${keys[@]}"; do
+  value=$(printenv "$key")
+  if [[ -n "$value" ]]; then
+    bindings+="--binding ${key}=${value} "
+  fi
+done
+
+# Trim any trailing whitespace
 bindings=$(echo $bindings | sed 's/[[:space:]]*$//')
 
 echo $bindings


### PR DESCRIPTION
When using `docker-compose` or `podman-compose`, the `.env.local` configuration can now be passed directly via the following command, removing the requirement for a volume mount:
```bash
podman-compose --env-file .env.local up -d
```

- Updated bindings.sh to retrieve and use environment variables directly, rather than relying on reading from .env.local as a volume mount.
- Enhanced security by handling sensitive information through environment variables instead of file-based configuration.
- Simplified setup, especially for users who prefer not to use volume mounts for injecting configuration files into containers.