### PR TITLE
feat: allow user to specify project name for zip file download

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -278,6 +278,7 @@ export class WorkbenchStore {
   async downloadZip() {
     const zip = new JSZip();
     const files = this.files.get();
+    const projectName = prompt('Enter the project name:', 'project') || 'project';
 
     for (const [filePath, dirent] of Object.entries(files)) {
       if (dirent?.type === 'file' && !dirent.isBinary) {
@@ -303,7 +304,7 @@ export class WorkbenchStore {
     }
 
     const content = await zip.generateAsync({ type: 'blob' });
-    saveAs(content, 'project.zip');
+    saveAs(content, `${projectName}.zip`);
   }
 
   async syncFiles(targetHandle: FileSystemDirectoryHandle) {


### PR DESCRIPTION
### Overview
This pull request introduces a new feature that enables users to specify a custom project name when downloading a ZIP file of their project. Previously, the downloaded ZIP file was saved with a default name (project.zip). Now, users are prompted to enter a preferred name, making the download more personalized and organized.

### Changes Made

- Added a prompt window that requests a custom project name from the user.
- The entered name is then applied to the ZIP file when downloaded, replacing the default project.zip filename.

### Benefits
- Enhances user experience by allowing a custom file naming option.
- Helps users better organize downloaded projects, especially when managing multiple projects.
- Testing
- Verified that the prompt appears and correctly captures user input.
- Tested ZIP file download with various inputs to confirm correct naming.