### PR TITLE
FileSync: Add option to load files from local filesystem

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -56,6 +56,7 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
   renderLogger.trace('Workbench');
 
   const [isSyncing, setIsSyncing] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const hasPreview = useStore(computed(workbenchStore.previews, (previews) => previews.length > 0));
   const showWorkbench = useStore(workbenchStore.showWorkbench);
@@ -116,6 +117,21 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
     }
   }, []);
 
+  const handleLoadFromFileSystem = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const directoryHandle = await window.showDirectoryPicker();
+      await workbenchStore.loadFromFileSystem(directoryHandle);
+      toast.success('Files loaded successfully');
+    } catch (error) {
+      console.error('Error loading files:', error);
+      toast.error('Failed to load files');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
   return (
     chatStarted && (
       <motion.div
@@ -152,6 +168,10 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
                     <PanelHeaderButton className="mr-1 text-sm" onClick={handleSyncFiles} disabled={isSyncing}>
                       {isSyncing ? <div className="i-ph:spinner" /> : <div className="i-ph:cloud-arrow-down" />}
                       {isSyncing ? 'Syncing...' : 'Sync Files'}
+                    </PanelHeaderButton>
+                    <PanelHeaderButton className="mr-1 text-sm" onClick={handleLoadFromFileSystem} disabled={isLoading}>
+                      {isLoading ? <div className="i-ph:spinner" /> : <div className="i-ph:cloud-arrow-up" />}
+                      {isLoading ? 'Loading...' : 'Load from Filesystem'}
                     </PanelHeaderButton>
                     <PanelHeaderButton
                       className="mr-1 text-sm"
@@ -230,6 +250,7 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
     )
   );
 });
+
 interface ViewProps extends HTMLMotionProps<'div'> {
   children: JSX.Element;
 }


### PR DESCRIPTION
# What's in here

This PR adds a button to the workbench to load files from the host. This is a step into the direction of keeping local files in sync with the webcontainer inside bolt.

## Checklist

- [x] Branch from the main branch
- [ ]  Update documentation if needed
- [x]  Manually verify all new functionality works as expected
- [x]  Keep PRs focused and atomic

## Tradeoffs

The initial idea to improve the  function was discarded, since this would increase complexity a lot: What should be done if files have been changed remote and locally within the webcontainer? Therefore, an explicit load was preferred.
