### PR TITLE
feat: add custom unique filename when download as zip

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -334,9 +334,6 @@ export class WorkbenchStore {
     const timestampHash = Date.now().toString(36).slice(-6);
     const uniqueProjectName = `${projectName}_${timestampHash}`;
 
-    // Prompt the user for a file name, prefilled with the project name
-    const fileName = prompt('Enter the file name', `${uniqueProjectName}.zip`);
-
     for (const [filePath, dirent] of Object.entries(files)) {
       if (dirent?.type === 'file' && !dirent.isBinary) {
         const relativePath = extractRelativePath(filePath);
@@ -358,15 +355,10 @@ export class WorkbenchStore {
         }
       }
     }
-
-
-
-
-  if (fileName) {
     // Generate the zip file and save it
     const content = await zip.generateAsync({ type: 'blob' });
-    saveAs(content, fileName);
-  }
+    saveAs(content, `${uniqueProjectName}.zip`);
+  
   }
 
   async syncFiles(targetHandle: FileSystemDirectoryHandle) {

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -327,7 +327,7 @@ export class WorkbenchStore {
   async downloadZip() {
     const zip = new JSZip();
     const files = this.files.get();
-    // Get the project name (assuming it's stored in this.projectName)
+    // Get the project name from the description input, or use a default name
     const projectName = (description.value ?? 'project').toLocaleLowerCase().split(' ').join('_');
   
     // Generate a simple 6-character hash based on the current timestamp

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -15,6 +15,7 @@ import { Octokit, type RestEndpointMethodTypes } from "@octokit/rest";
 import * as nodePath from 'node:path';
 import type { WebContainerProcess } from '@webcontainer/api';
 import { extractRelativePath } from '~/utils/diff';
+import { description } from '../persistence';
 
 export interface ArtifactState {
   id: string;
@@ -171,6 +172,7 @@ export class WorkbenchStore {
     this.#editorStore.setSelectedFile(filePath);
   }
 
+
   async saveFile(filePath: string) {
     const documents = this.#editorStore.documents.get();
     const document = documents[filePath];
@@ -325,6 +327,15 @@ export class WorkbenchStore {
   async downloadZip() {
     const zip = new JSZip();
     const files = this.files.get();
+    // Get the project name (assuming it's stored in this.projectName)
+    const projectName = (description.value ?? 'project').toLocaleLowerCase().split(' ').join('_');
+  
+    // Generate a simple 6-character hash based on the current timestamp
+    const timestampHash = Date.now().toString(36).slice(-6);
+    const uniqueProjectName = `${projectName}_${timestampHash}`;
+
+    // Prompt the user for a file name, prefilled with the project name
+    const fileName = prompt('Enter the file name', `${uniqueProjectName}.zip`);
 
     for (const [filePath, dirent] of Object.entries(files)) {
       if (dirent?.type === 'file' && !dirent.isBinary) {
@@ -348,8 +359,14 @@ export class WorkbenchStore {
       }
     }
 
+
+
+
+  if (fileName) {
+    // Generate the zip file and save it
     const content = await zip.generateAsync({ type: 'blob' });
-    saveAs(content, 'project.zip');
+    saveAs(content, fileName);
+  }
   }
 
   async syncFiles(targetHandle: FileSystemDirectoryHandle) {


### PR DESCRIPTION
**Description**

This pull request introduces a new functionality that enhances the user experience when downloading ZIP files. When a user clicks the "Download ZIP" button, a prompt is displayed to allow the user to edit the filename before proceeding with the download. By default, the filename is pre-filled with a unique project name that includes a hash, ensuring uniqueness.

**Key Features**

**Pre-filled Default Filename:**

- The filename includes a unique project name (e.g., ProjectName-<unique-hash>.zip).
- The hash is generated to ensure the file name remains distinct for each project.


![afbeelding](https://github.com/user-attachments/assets/05759588-eacb-4f20-83c1-0846c2b798ba)
