### PR TITLE
Should not provide hard-coded OLLAMA_API_BASE_URL value in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ GOOGLE_GENERATIVE_AI_API_KEY=
 
 # You only need this environment variable set if you want to use oLLAMA models
 # EXAMPLE http://localhost:11434
-OLLAMA_API_BASE_URL=http://localhost:11434
+OLLAMA_API_BASE_URL=
 
 # You only need this environment variable set if you want to use OpenAI Like models
 OPENAI_LIKE_API_BASE_URL=


### PR DESCRIPTION
localhost:11434 made its way into .env.example. This will fail for anyone attempting to use ottodev with local machine ollama.