### PR TITLE
add bedrock cerebras and pixtral

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,17 @@ MISTRAL_API_KEY=
 # Example: http://localhost:1234
 LMSTUDIO_API_BASE_URL=
 
+# Get your Cerebras API Key by following these instructions -
+# https://github.com/Cerebras/inference-examples/blob/main/getting-started/README.md
+# You only need this environment variable set if you want to use Cerebras models
+CEREBRAS_API_KEY=
+
+# Get your AWS credentials from your AWS Console
+AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY=YOUR_SECRET_ACCESS_KEY
+AWS_REGION=YOUR_REGION
+
+
 # Get your xAI API key
 # https://x.ai/api
 # You only need this environment variable set if you want to use xAI models

--- a/app/lib/.server/llm/api-key.ts
+++ b/app/lib/.server/llm/api-key.ts
@@ -33,6 +33,10 @@ export function getAPIKey(cloudflareEnv: Env, provider: string, userApiKeys?: Re
       return env.OPENAI_LIKE_API_KEY || cloudflareEnv.OPENAI_LIKE_API_KEY;
     case "xAI":
       return env.XAI_API_KEY || cloudflareEnv.XAI_API_KEY;
+    case "Cerebras":
+      return env.CEREBRAS_API_KEY || cloudflareEnv.CEREBRAS_API_KEY;
+    case 'Bedrock':
+      return env.AMAZON_BEDROCK_API_KEY || cloudflareEnv.AMAZON_BEDROCK_API_KEY;
     default:
       return "";
   }

--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -7,6 +7,12 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { ollama } from 'ollama-ai-provider';
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createMistral } from '@ai-sdk/mistral';
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
 
 export function getAnthropicModel(apiKey: string, model: string) {
   const anthropic = createAnthropic({
@@ -50,6 +56,25 @@ export function getGoogleModel(apiKey: string, model: string) {
 export function getGroqModel(apiKey: string, model: string) {
   const openai = createOpenAI({
     baseURL: 'https://api.groq.com/openai/v1',
+    apiKey,
+  });
+
+  return openai(model);
+}
+
+export function getAmazonBedrockModel(apiKey: string, model: string) {
+  const amazonBedrock = createAmazonBedrock({
+    region: process.env.AWS_REGION,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  });
+
+  return amazonBedrock(model);
+}
+
+export function getCerebrasModel(apiKey: string, model: string) {
+  const openai = createOpenAI({
+    baseURL: 'https://api.cerebras.ai/v1',
     apiKey,
   });
 
@@ -114,6 +139,10 @@ export function getModel(provider: string, model: string, env: Env, apiKeys?: Re
       return getOpenRouterModel(apiKey, model);
     case 'Google':
       return getGoogleModel(apiKey, model);
+    case 'Cerebras':
+      return getCerebrasModel(apiKey, model);
+    case 'Bedrock':
+      return getAmazonBedrockModel(apiKey, model);  
     case 'OpenAILike':
       return getOpenAILikeModel(baseURL,apiKey, model);
     case 'Deepseek':

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -105,8 +105,22 @@ const PROVIDER_LIST: ProviderInfo[] = [
       { name: 'mistral-small-latest', label: 'Mistral Small', provider: 'Mistral' },
       { name: 'codestral-latest', label: 'Codestral', provider: 'Mistral' },
       { name: 'mistral-large-latest', label: 'Mistral Large Latest', provider: 'Mistral' }
+      { name: 'pixtral-12b-2409', label: 'Pixtral 12B', provider: 'Mistral' },
     ],
     getApiKeyLink: 'https://console.mistral.ai/api-keys/'
+  }, {
+    name: 'Cerebras',
+    staticModels: [
+      { name: 'llama3.1-8b', label: 'Llama 3.1 8B', provider: 'Cerebras' },
+      { name: 'llama3.1-70b', label: 'Llama 3.1 70B', provider: 'Cerebras' }
+    ],
+    getApiKeyLink: 'https://inference-docs.cerebras.ai/quickstart'
+  }, {
+    name: 'Bedrock',
+    staticModels: [
+      { name: 'anthropic.claude-3-5-sonnet-20241022-v2:0', label: 'Claude 3.5 Sonnet v2', provider: 'Bedrock' },
+    ],
+    getApiKeyLink: 'https://platform.deepseek.com/api_keys'
   }, {
     name: 'LMStudio',
     staticModels: [],

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.39",
+    "@ai-sdk/amazon-bedrock": "^0.0.33",
+    "dotenv": "^16.4.5",
     "@ai-sdk/google": "^0.0.52",
     "@ai-sdk/mistral": "^0.0.43",
     "@ai-sdk/openai": "^0.0.66",


### PR DESCRIPTION
Added amazon bedrock (token limit manual change reqd to use) and added cerebras as asked in another pr. pixtral was restored. @coleam00 Please look into the artificial api token limit for amazon bedrock, it's important to have bedrock as well.