### PR TITLE
Update the Google Gemini models list

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -58,7 +58,11 @@ const PROVIDER_LIST: ProviderInfo[] = [
     name: 'Google',
     staticModels: [
       { name: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash', provider: 'Google' },
-      { name: 'gemini-1.5-pro-latest', label: 'Gemini 1.5 Pro', provider: 'Google' }
+      { name: 'gemini-1.5-flash-002', label: 'Gemini 1.5 Flash', provider: 'Google' },
+      { name: 'gemini-1.5-flash-8b', label: 'Gemini 1.5 Flash 8b', provider: 'Google' },
+      { name: 'gemini-1.5-pro-latest', label: 'Gemini 1.5 Pro', provider: 'Google' },
+      { name: 'gemini-1.5-pro-002', label: 'Gemini 1.5 Pro', provider: 'Google' },
+      { name: 'gemini-exp-1114', label: 'Gemini exp-1114', provider: 'Google' }
     ],
     getApiKeyLink: 'https://aistudio.google.com/app/apikey'
   }, {

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -58,10 +58,10 @@ const PROVIDER_LIST: ProviderInfo[] = [
     name: 'Google',
     staticModels: [
       { name: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash', provider: 'Google' },
-      { name: 'gemini-1.5-flash-002', label: 'Gemini 1.5 Flash', provider: 'Google' },
-      { name: 'gemini-1.5-flash-8b', label: 'Gemini 1.5 Flash 8b', provider: 'Google' },
+      { name: 'gemini-1.5-flash-002', label: 'Gemini 1.5 Flash-002', provider: 'Google' },
+      { name: 'gemini-1.5-flash-8b', label: 'Gemini 1.5 Flash-8b', provider: 'Google' },
       { name: 'gemini-1.5-pro-latest', label: 'Gemini 1.5 Pro', provider: 'Google' },
-      { name: 'gemini-1.5-pro-002', label: 'Gemini 1.5 Pro', provider: 'Google' },
+      { name: 'gemini-1.5-pro-002', label: 'Gemini 1.5 Pro-002', provider: 'Google' },
       { name: 'gemini-exp-1114', label: 'Gemini exp-1114', provider: 'Google' }
     ],
     getApiKeyLink: 'https://aistudio.google.com/app/apikey'


### PR DESCRIPTION
I've added all the present models from Google Gemini to the list. Did a bit of testing with exp-1114 and it works great.