### PR TITLE
[fix]: shell commands execution failure on app reload

### DIFF
--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -95,7 +95,7 @@ export class ActionRunner {
 
     this.#currentExecutionPromise = this.#currentExecutionPromise
       .then(() => {
-        this.#executeAction(actionId, isStreaming);
+        return this.#executeAction(actionId, isStreaming);
       })
       .catch((error) => {
         console.error('Action failed:', error);

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -100,6 +100,7 @@ export class ActionRunner {
       .catch((error) => {
         console.error('Action failed:', error);
       });
+      return this.#currentExecutionPromise;
   }
 
   async #executeAction(actionId: string, isStreaming: boolean = false) {

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -11,7 +11,7 @@ interface Logger {
   setLevel: (level: DebugLevel) => void;
 }
 
-let currentLevel: DebugLevel = (import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV) ? 'debug' : 'info';
+let currentLevel: DebugLevel = import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV ? 'debug' : 'info';
 
 const isWorker = 'HTMLRewriter' in globalThis;
 const supportsColor = !isWorker;


### PR DESCRIPTION
### Behavior
When the app reloads, it re-runs all the commands, but the shell commands were failing. To fix this issue, I've made the following change in the app/lib/runtime/action-runner.ts file:

Now the actions are properly awaited

Before Change:
![image](https://github.com/user-attachments/assets/e827285e-32cb-497d-b5a2-5c63ecc8e5ea)

After Change:
![image](https://github.com/user-attachments/assets/c63371c7-6ce9-4669-b9d5-d9827c36f143)

### Key Change
Addition of the return statement before calling this.#executeAction. This ensures that the promise returned by this.#executeAction is properly awaited and propagated through the promise chain, preventing the subsequent actions from running before the current one has completed.

### Testing
- ✅ Manually verified that shell commands now execute successfully during app reload
- ✅ Confirmed actions run in the correct sequence  

Note: Code changes also contains a prettier fix regarding `let currentLevel: DebugLevel = (import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV) ? 'debug' : 'info';`