### PR TITLE
[fix]: artifact actionlist rendering in chat

### DIFF
--- a/app/components/chat/Markdown.spec.ts
+++ b/app/components/chat/Markdown.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { stripCodeFenceFromArtifact } from './Markdown';
+
+describe('stripCodeFenceFromArtifact', () => {
+  it('should remove code fences around artifact element', () => {
+    const input = "```xml\n<div class='__boltArtifact__'></div>\n```";
+    const expected = "\n<div class='__boltArtifact__'></div>\n";
+    expect(stripCodeFenceFromArtifact(input)).toBe(expected);
+  });
+
+  it('should handle code fence with language specification', () => {
+    const input = "```typescript\n<div class='__boltArtifact__'></div>\n```";
+    const expected = "\n<div class='__boltArtifact__'></div>\n";
+    expect(stripCodeFenceFromArtifact(input)).toBe(expected);
+  });
+
+  it('should not modify content without artifacts', () => {
+    const input = '```\nregular code block\n```';
+    expect(stripCodeFenceFromArtifact(input)).toBe(input);
+  });
+
+  it('should handle empty input', () => {
+    expect(stripCodeFenceFromArtifact('')).toBe('');
+  });
+
+  it('should handle artifact without code fences', () => {
+    const input = "<div class='__boltArtifact__'></div>";
+    expect(stripCodeFenceFromArtifact(input)).toBe(input);
+  });
+
+  it('should handle multiple artifacts but only remove fences around them', () => {
+    const input = [
+      'Some text',
+      '```typescript',
+      "<div class='__boltArtifact__'></div>",
+      '```',
+      '```',
+      'regular code',
+      '```',
+    ].join('\n');
+
+    const expected = ['Some text', '', "<div class='__boltArtifact__'></div>", '', '```', 'regular code', '```'].join(
+      '\n',
+    );
+
+    expect(stripCodeFenceFromArtifact(input)).toBe(expected);
+  });
+});

--- a/app/components/chat/Markdown.tsx
+++ b/app/components/chat/Markdown.tsx
@@ -68,7 +68,51 @@ export const Markdown = memo(({ children, html = false, limitedMarkdown = false 
       remarkPlugins={remarkPlugins(limitedMarkdown)}
       rehypePlugins={rehypePlugins(html)}
     >
-      {children}
+      {stripCodeFenceFromArtifact(children)}
     </ReactMarkdown>
   );
 });
+
+/**
+ * Removes code fence markers (```) surrounding an artifact element while preserving the artifact content.
+ * This is necessary because artifacts should not be wrapped in code blocks when rendered for rendering action list.
+ *
+ * @param content - The markdown content to process
+ * @returns The processed content with code fence markers removed around artifacts
+ *
+ * @example
+ * // Removes code fences around artifact
+ * const input = "```xml\n<div class='__boltArtifact__'></div>\n```";
+ * stripCodeFenceFromArtifact(input);
+ * // Returns: "\n<div class='__boltArtifact__'></div>\n"
+ *
+ * @remarks
+ * - Only removes code fences that directly wrap an artifact (marked with __boltArtifact__ class)
+ * - Handles code fences with optional language specifications (e.g. ```xml, ```typescript)
+ * - Preserves original content if no artifact is found
+ * - Safely handles edge cases like empty input or artifacts at start/end of content
+ */
+export const stripCodeFenceFromArtifact = (content: string) => {
+  if (!content || !content.includes('__boltArtifact__')) {
+    return content;
+  }
+
+  const lines = content.split('\n');
+  const artifactLineIndex = lines.findIndex((line) => line.includes('__boltArtifact__'));
+
+  // Return original content if artifact line not found
+  if (artifactLineIndex === -1) {
+    return content;
+  }
+
+  // Check previous line for code fence
+  if (artifactLineIndex > 0 && lines[artifactLineIndex - 1]?.trim().match(/^```\w*$/)) {
+    lines[artifactLineIndex - 1] = '';
+  }
+
+  if (artifactLineIndex < lines.length - 1 && lines[artifactLineIndex + 1]?.trim().match(/^```$/)) {
+    lines[artifactLineIndex + 1] = '';
+  }
+
+  return lines.join('\n');
+};

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -11,7 +11,7 @@ interface Logger {
   setLevel: (level: DebugLevel) => void;
 }
 
-let currentLevel: DebugLevel = (import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV) ? 'debug' : 'info';
+let currentLevel: DebugLevel = import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV ? 'debug' : 'info';
 
 const isWorker = 'HTMLRewriter' in globalThis;
 const supportsColor = !isWorker;


### PR DESCRIPTION
## Fix Artifact Rendering in Chat Messages

### Problem
When chat messages contain Artifact components (like ActionLists) wrapped in code fences (```), they are rendered as plain code blocks instead of rendering via Artifact.tsx component.

```
// ignore escapes
/`/`/`xml
<div class="__boltArtifact__" data-message-id="RVO8njc"></div>
/`/`/`
```

### Root Cause
ReactMarkdown processes code-fenced content before component rendering, causing the __boltArtifact__ elements to be treated as plain text within code blocks rather than being passed to the Artifact component.

### Solution
Added preprocessing step to remove code fence markers specifically around artifact elements:
  - Introduced stripCodeFenceFromArtifact function in app/components/chat/Markdown.tsx
  - Added unit tests in app/components/chat/Markdown.spec.ts
 
 ### Alternative Approach Considered
Explored handling at the component level through ReactMarkdown's AST:

```typescript
pre: (props) => {
  const textContent = node?.children?.[0]?.children?.[0];
  // Check text content for artifact markup
  if (textContent.value.includes('__boltArtifact__')) {
    const messageId = extractMessageId(textContent.value);
     // validate if messageId exists
    return <Artifact messageId={messageId} />;
  }
  // ... regular code block handling
}
```

### Why Current Solution Was Chosen
- Simpler Mental Model : Preprocessing the string is more straightforward than dealing with AST.
- Less Fragile : Doesn't depend on specific AST structure which could change with ReactMarkdown updates
- Better Separation of Concerns : Handles artifact cleanup before markdown processing rather than mixing concerns in component rendering
- Easier Testing : String manipulation is simpler to test than component rendering logic
- More Maintainable : Future developers can more easily understand and modify string preprocessing than AST traversal

### Changes
#### Before
<img width="589" alt="image" src="https://github.com/user-attachments/assets/6aa9641e-d977-41b1-bba2-6bea9b48702c">

#### After
<img width="578" alt="image" src="https://github.com/user-attachments/assets/e791cc2f-8950-402f-8da7-e12ae427deb0">

### Impact
- ✅ Artifacts now render as interactive components in chat
- ✅ Preserves code block rendering for actual code snippets
- ✅ Improves chat message readability and functionality
- ✅ Added test coverage for preprocessing

### Testing
- ✅ Verified Artifact and ActionList rendering in chat messages
- ✅  Added unit tests for `stripCodeFenceFromArtifact`
- ✅ Confirmed regular code blocks still render correctly
- ✅ Tested edge cases (nested code blocks, multiple artifacts)


