### PR TITLE
[feat][WIP]: OpenAI Like and Ollama UI change

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -25,38 +25,91 @@ import { ExamplePrompts } from '~/components/chat/ExamplePrompts';
 // @ts-ignore TODO: Introduce proper types
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ModelSelector = ({ model, setModel, provider, setProvider, modelList, providerList, apiKeys }) => {
-  return (
-    <div className="mb-2 flex gap-2 flex-col sm:flex-row">
-      <select
-        value={provider?.name}
-        onChange={(e) => {
-          setProvider(providerList.find((p: ProviderInfo) => p.name === e.target.value));
+  const [customUrl, setCustomUrl] = useState('');
+  const [customModel, setCustomModel] = useState('');
 
-          const firstModel = [...modelList].find((m) => m.provider == e.target.value);
-          setModel(firstModel ? firstModel.name : '');
-        }}
-        className="flex-1 p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none focus:ring-2 focus:ring-bolt-elements-focus transition-all"
-      >
-        {providerList.map((provider: ProviderInfo) => (
-          <option key={provider.name} value={provider.name}>
-            {provider.name}
-          </option>
-        ))}
-      </select>
-      <select
-        key={provider?.name}
-        value={model}
-        onChange={(e) => setModel(e.target.value)}
-        className="flex-1 p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none focus:ring-2 focus:ring-bolt-elements-focus transition-all lg:max-w-[70%] "
-      >
-        {[...modelList]
-          .filter((e) => e.provider == provider?.name && e.name)
-          .map((modelOption) => (
-            <option key={modelOption.name} value={modelOption.name}>
-              {modelOption.label}
+  useEffect(() => {
+    if (provider?.name === 'OpenAILike') {
+      setCustomUrl(import.meta.env.OPENAI_LIKE_API_BASE_URL || '');
+      setCustomModel(model || '');
+    } else if (provider?.name === 'Ollama') {
+      setCustomUrl(import.meta.env.OLLAMA_API_BASE_URL || 'http://localhost:11434');
+    }
+  }, [provider?.name]);
+
+  return (
+    <div className="mb-2 flex gap-2 flex-col">
+      <div className="flex gap-2 flex-col sm:flex-row">
+        <select
+          value={provider?.name}
+          onChange={(e) => {
+            setProvider(providerList.find((p: ProviderInfo) => p.name === e.target.value));
+
+            const firstModel = [...modelList].find((m) => m.provider == e.target.value);
+            setModel(firstModel ? firstModel.name : '');
+          }}
+          className="flex-1 p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none focus:ring-2 focus:ring-bolt-elements-focus transition-all"
+        >
+          {providerList.map((provider: ProviderInfo) => (
+            <option key={provider.name} value={provider.name}>
+              {provider.name}
             </option>
           ))}
-      </select>
+        </select>
+        {provider?.name !== 'OpenAILike' && (
+          <select
+            key={provider?.name}
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="flex-1 p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none focus:ring-2 focus:ring-bolt-elements-focus transition-all lg:max-w-[70%]"
+          >
+            {[...modelList]
+              .filter((e) => e.provider == provider?.name && e.name)
+              .map((modelOption) => (
+                <option key={modelOption.name} value={modelOption.name}>
+                  {modelOption.label}
+                </option>
+              ))}
+          </select>
+        )}
+      </div>
+      {(provider?.name === 'OpenAILike' || provider?.name === 'Ollama') && (
+        <div className="flex gap-2 flex-col sm:flex-row">
+          <input
+            type="text"
+            placeholder={
+              provider?.name === 'Ollama'
+                ? 'Ollama API URL (default: http://localhost:11434)'
+                : 'Enter API Base URL (e.g., http://localhost:1234/v1)'
+            }
+            value={customUrl}
+            onChange={(e) => {
+              setCustomUrl(e.target.value);
+
+              if (typeof window !== 'undefined') {
+                if (provider?.name === 'OpenAILike') {
+                  window.localStorage.setItem('OPENAI_LIKE_API_BASE_URL', e.target.value);
+                } else if (provider?.name === 'Ollama') {
+                  window.localStorage.setItem('OLLAMA_API_BASE_URL', e.target.value || 'http://localhost:11434');
+                }
+              }
+            }}
+            className="flex-1 p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none focus:ring-2 focus:ring-bolt-elements-focus transition-all"
+          />
+          {provider?.name === 'OpenAILike' && (
+            <input
+              type="text"
+              placeholder="Enter Model Name"
+              value={customModel}
+              onChange={(e) => {
+                setCustomModel(e.target.value);
+                setModel(e.target.value);
+              }}
+              className="flex-1 p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none focus:ring-2 focus:ring-bolt-elements-focus transition-all"
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -24,9 +24,13 @@ export function getAnthropicModel(apiKey: OptionalApiKey, model: string) {
   return anthropic(model);
 }
 export function getOpenAILikeModel(baseURL: string, apiKey: OptionalApiKey, model: string) {
+  if (!baseURL) {
+    throw new Error('OpenAI Like API Base URL is required');
+  }
+
   const openai = createOpenAI({
-    baseURL,
-    apiKey,
+    baseURL: baseURL.endsWith('/v1') ? baseURL : `${baseURL}/v1`,
+    apiKey: apiKey || 'not-needed',
   });
 
   return openai(model);

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -81,6 +81,7 @@ export class ActionRunner {
 
     if (!action) {
       unreachable(`Action ${actionId} not found`);
+      return;
     }
 
     if (action.executed) {
@@ -100,7 +101,6 @@ export class ActionRunner {
       .catch((error) => {
         console.error('Action failed:', error);
       });
-      return this.#currentExecutionPromise;
   }
 
   async #executeAction(actionId: string, isStreaming: boolean = false) {

--- a/app/types/model.ts
+++ b/app/types/model.ts
@@ -7,4 +7,5 @@ export type ProviderInfo = {
   getApiKeyLink?: string;
   labelForGetApiKey?: string;
   icon?: string;
+  description?: string;
 };

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -11,7 +11,7 @@ interface Logger {
   setLevel: (level: DebugLevel) => void;
 }
 
-let currentLevel: DebugLevel = import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV ? 'debug' : 'info';
+let currentLevel: DebugLevel = (import.meta.env.VITE_LOG_LEVEL ?? import.meta.env.DEV) ? 'debug' : 'info';
 
 const isWorker = 'HTMLRewriter' in globalThis;
 const supportsColor = !isWorker;


### PR DESCRIPTION
From issue: https://github.com/coleam00/bolt.new-any-llm/issues/461

When selecting OpenAI Like I would like to have a a textbox for the url and textbox for model name. Since this will not be retrieved automatically. Then The Ollama provider could extend from that with a populated url but editable, and a model dropdown for the model name as it is now.

![a1](https://github.com/user-attachments/assets/11baa7c7-3f98-49c0-819d-efd532a1f8f1)

![b1](https://github.com/user-attachments/assets/03cb89b2-a45a-4f27-8fbc-83db54dc1ab4)
