### PR TITLE
Feat: add vue support for codemirror

### DIFF
--- a/app/components/editor/codemirror/languages.ts
+++ b/app/components/editor/codemirror/languages.ts
@@ -2,6 +2,13 @@ import { LanguageDescription } from '@codemirror/language';
 
 export const supportedLanguages = [
   LanguageDescription.of({
+    name: 'VUE',
+    extensions: ['vue'],
+    async load() {
+      return import('@codemirror/lang-vue').then((module) => module.vue());
+    },
+  }),
+  LanguageDescription.of({
     name: 'TS',
     extensions: ['ts'],
     async load() {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@codemirror/lang-markdown": "^6.3.1",
     "@codemirror/lang-python": "^6.1.6",
     "@codemirror/lang-sass": "^6.0.2",
+    "@codemirror/lang-vue": "^0.1.3",
     "@codemirror/lang-wast": "^6.0.2",
     "@codemirror/language": "^6.10.6",
     "@codemirror/search": "^6.5.8",


### PR DESCRIPTION
Add vue language support (highlighting) for codemirror

<img width="1126" alt="Screenshot 2024-12-07 at 11 55 02 AM" src="https://github.com/user-attachments/assets/35ec246d-e3a5-4013-9417-c670ff478569">
