### PR TITLE
Add command detection to git import flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ https://thinktank.ottomator.ai
 - ✅ Mobile friendly (@qwikode)
 - ✅ Better prompt enhancing (@SujalXplores)
 - ✅ Attach images to prompts (@atrokhym)
+- ✅ Detect package.json and commands to auto install and run preview for folder and git import (@wonderwhy-er)
 - ⬜ **HIGH PRIORITY** - Prevent Bolt from rewriting files as often (file locking and diffs)
 - ⬜ **HIGH PRIORITY** - Better prompting for smaller LLMs (code window sometimes doesn't start)
 - ⬜ **HIGH PRIORITY** - Run agents in the backend as opposed to a single model call

--- a/app/components/chat/GitCloneButton.tsx
+++ b/app/components/chat/GitCloneButton.tsx
@@ -2,6 +2,8 @@ import ignore from 'ignore';
 import { useGit } from '~/lib/hooks/useGit';
 import type { Message } from 'ai';
 import WithTooltip from '~/components/ui/Tooltip';
+import { detectProjectCommands, createCommandsMessage } from '~/utils/projectCommands';
+import { generateId } from '~/utils/fileUtils';
 
 const IGNORE_PATTERNS = [
   'node_modules/**',
@@ -28,7 +30,6 @@ const IGNORE_PATTERNS = [
 ];
 
 const ig = ignore().add(IGNORE_PATTERNS);
-const generateId = () => Math.random().toString(36).substring(2, 15);
 
 interface GitCloneButtonProps {
   className?: string;
@@ -52,36 +53,47 @@ export default function GitCloneButton({ importChat }: GitCloneButtonProps) {
         console.log(filePaths);
 
         const textDecoder = new TextDecoder('utf-8');
-        const message: Message = {
+
+        // Convert files to common format for command detection
+        const fileContents = filePaths
+          .map((filePath) => {
+            const { data: content, encoding } = data[filePath];
+            return {
+              path: filePath,
+              content: encoding === 'utf8' ? content : content instanceof Uint8Array ? textDecoder.decode(content) : '',
+            };
+          })
+          .filter((f) => f.content);
+
+        // Detect and create commands message
+        const commands = await detectProjectCommands(fileContents);
+        const commandsMessage = createCommandsMessage(commands);
+
+        // Create files message
+        const filesMessage: Message = {
           role: 'assistant',
           content: `Cloning the repo ${repoUrl} into ${workdir}
-<boltArtifact id="imported-files" title="Git Cloned Files" type="bundled" >           
-          ${filePaths
-            .map((filePath) => {
-              const { data: content, encoding } = data[filePath];
-
-              if (encoding === 'utf8') {
-                return `<boltAction type="file" filePath="${filePath}">
-${content}
-</boltAction>`;
-              } else if (content instanceof Uint8Array) {
-                return `<boltAction type="file" filePath="${filePath}">
-${textDecoder.decode(content)}
-</boltAction>`;
-              } else {
-                return '';
-              }
-            })
-            .join('\n')}
- </boltArtifact>`,
+<boltArtifact id="imported-files" title="Git Cloned Files" type="bundled">           
+${fileContents
+  .map(
+    (file) =>
+      `<boltAction type="file" filePath="${file.path}">
+${file.content}
+</boltAction>`,
+  )
+  .join('\n')}
+</boltArtifact>`,
           id: generateId(),
           createdAt: new Date(),
         };
-        console.log(JSON.stringify(message));
 
-        importChat(`Git Project:${repoUrl.split('/').slice(-1)[0]}`, [message]);
+        const messages = [filesMessage];
 
-        // console.log(files);
+        if (commandsMessage) {
+          messages.push(commandsMessage);
+        }
+
+        await importChat(`Git Project:${repoUrl.split('/').slice(-1)[0]}`, messages);
       }
     }
   };

--- a/app/components/chat/ImportFolderButton.tsx
+++ b/app/components/chat/ImportFolderButton.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import type { Message } from 'ai';
 import { toast } from 'react-toastify';
-import { MAX_FILES, isBinaryFile, shouldIncludeFile } from '../../utils/fileUtils';
-import { createChatFromFolder } from '../../utils/folderImport';
+import { MAX_FILES, isBinaryFile, shouldIncludeFile } from '~/utils/fileUtils';
+import { createChatFromFolder } from '~/utils/folderImport';
 
 interface ImportFolderButtonProps {
   className?: string;
@@ -17,12 +17,14 @@ export const ImportFolderButton: React.FC<ImportFolderButtonProps> = ({ classNam
 
     if (allFiles.length > MAX_FILES) {
       toast.error(
-        `This folder contains ${allFiles.length.toLocaleString()} files. This product is not yet optimized for very large projects. Please select a folder with fewer than ${MAX_FILES.toLocaleString()} files.`
+        `This folder contains ${allFiles.length.toLocaleString()} files. This product is not yet optimized for very large projects. Please select a folder with fewer than ${MAX_FILES.toLocaleString()} files.`,
       );
       return;
     }
+
     const folderName = allFiles[0]?.webkitRelativePath.split('/')[0] || 'Unknown Folder';
     setIsLoading(true);
+
     const loadingToast = toast.loading(`Importing ${folderName}...`);
 
     try {

--- a/app/components/chat/SendButton.client.tsx
+++ b/app/components/chat/SendButton.client.tsx
@@ -23,6 +23,7 @@ export const SendButton = ({ show, isStreaming, disabled, onClick }: SendButtonP
           disabled={disabled}
           onClick={(event) => {
             event.preventDefault();
+
             if (!disabled) {
               onClick?.(event);
             }

--- a/app/utils/fileUtils.ts
+++ b/app/utils/fileUtils.ts
@@ -29,10 +29,12 @@ export const isBinaryFile = async (file: File): Promise<boolean> => {
 
   for (let i = 0; i < buffer.length; i++) {
     const byte = buffer[i];
+
     if (byte === 0 || (byte < 32 && byte !== 9 && byte !== 10 && byte !== 13)) {
       return true;
     }
   }
+
   return false;
 };
 
@@ -41,8 +43,11 @@ export const shouldIncludeFile = (path: string): boolean => {
 };
 
 const readPackageJson = async (files: File[]): Promise<{ scripts?: Record<string, string> } | null> => {
-  const packageJsonFile = files.find(f => f.webkitRelativePath.endsWith('package.json'));
-  if (!packageJsonFile) return null;
+  const packageJsonFile = files.find((f) => f.webkitRelativePath.endsWith('package.json'));
+
+  if (!packageJsonFile) {
+    return null;
+  }
 
   try {
     const content = await new Promise<string>((resolve, reject) => {
@@ -59,29 +64,32 @@ const readPackageJson = async (files: File[]): Promise<{ scripts?: Record<string
   }
 };
 
-export const detectProjectType = async (files: File[]): Promise<{ type: string; setupCommand: string; followupMessage: string }> => {
-  const hasFile = (name: string) => files.some(f => f.webkitRelativePath.endsWith(name));
+export const detectProjectType = async (
+  files: File[],
+): Promise<{ type: string; setupCommand: string; followupMessage: string }> => {
+  const hasFile = (name: string) => files.some((f) => f.webkitRelativePath.endsWith(name));
 
   if (hasFile('package.json')) {
     const packageJson = await readPackageJson(files);
     const scripts = packageJson?.scripts || {};
-    
+
     // Check for preferred commands in priority order
     const preferredCommands = ['dev', 'start', 'preview'];
-    const availableCommand = preferredCommands.find(cmd => scripts[cmd]);
-    
+    const availableCommand = preferredCommands.find((cmd) => scripts[cmd]);
+
     if (availableCommand) {
       return {
         type: 'Node.js',
         setupCommand: `npm install && npm run ${availableCommand}`,
-        followupMessage: `Found "${availableCommand}" script in package.json. Running "npm run ${availableCommand}" after installation.`
+        followupMessage: `Found "${availableCommand}" script in package.json. Running "npm run ${availableCommand}" after installation.`,
       };
     }
 
     return {
       type: 'Node.js',
       setupCommand: 'npm install',
-      followupMessage: 'Would you like me to inspect package.json to determine the available scripts for running this project?'
+      followupMessage:
+        'Would you like me to inspect package.json to determine the available scripts for running this project?',
     };
   }
 
@@ -89,7 +97,7 @@ export const detectProjectType = async (files: File[]): Promise<{ type: string; 
     return {
       type: 'Static',
       setupCommand: 'npx --yes serve',
-      followupMessage: ''
+      followupMessage: '',
     };
   }
 

--- a/app/utils/projectCommands.ts
+++ b/app/utils/projectCommands.ts
@@ -1,0 +1,80 @@
+import type { Message } from 'ai';
+import { generateId } from './fileUtils';
+
+export interface ProjectCommands {
+  type: string;
+  setupCommand: string;
+  followupMessage: string;
+}
+
+interface FileContent {
+  content: string;
+  path: string;
+}
+
+export async function detectProjectCommands(files: FileContent[]): Promise<ProjectCommands> {
+  const hasFile = (name: string) => files.some((f) => f.path.endsWith(name));
+
+  if (hasFile('package.json')) {
+    const packageJsonFile = files.find((f) => f.path.endsWith('package.json'));
+
+    if (!packageJsonFile) {
+      return { type: '', setupCommand: '', followupMessage: '' };
+    }
+
+    try {
+      const packageJson = JSON.parse(packageJsonFile.content);
+      const scripts = packageJson?.scripts || {};
+
+      // Check for preferred commands in priority order
+      const preferredCommands = ['dev', 'start', 'preview'];
+      const availableCommand = preferredCommands.find((cmd) => scripts[cmd]);
+
+      if (availableCommand) {
+        return {
+          type: 'Node.js',
+          setupCommand: `npm install && npm run ${availableCommand}`,
+          followupMessage: `Found "${availableCommand}" script in package.json. Running "npm run ${availableCommand}" after installation.`,
+        };
+      }
+
+      return {
+        type: 'Node.js',
+        setupCommand: 'npm install',
+        followupMessage:
+          'Would you like me to inspect package.json to determine the available scripts for running this project?',
+      };
+    } catch (error) {
+      console.error('Error parsing package.json:', error);
+      return { type: '', setupCommand: '', followupMessage: '' };
+    }
+  }
+
+  if (hasFile('index.html')) {
+    return {
+      type: 'Static',
+      setupCommand: 'npx --yes serve',
+      followupMessage: '',
+    };
+  }
+
+  return { type: '', setupCommand: '', followupMessage: '' };
+}
+
+export function createCommandsMessage(commands: ProjectCommands): Message | null {
+  if (!commands.setupCommand) {
+    return null;
+  }
+
+  return {
+    role: 'assistant',
+    content: `
+<boltArtifact id="project-setup" title="Project Setup">
+<boltAction type="shell">
+${commands.setupCommand}
+</boltAction>
+</boltArtifact>${commands.followupMessage ? `\n\n${commands.followupMessage}` : ''}`,
+    id: generateId(),
+    createdAt: new Date(),
+  };
+}


### PR DESCRIPTION
I already added this for folder import before https://github.com/coleam00/bolt.new-any-llm/pull/426
Now extracted and reused for git import as well

Here is video:

https://github.com/user-attachments/assets/6cff27cc-41eb-4353-8770-9eaec0b06d46

Purpose:
Removes couple of steps, especially for non developers, in seeing preview of loaded project.

Way it works is that it checks if there is package.json file, reads it, checks for commands, runs install and tries to run commands
https://github.com/coleam00/bolt.new-any-llm/pull/589/files#diff-6974fdf2657c6325130ca11f89326ffe1297cb97971c3c377e712387ce45cec5R30

In case there is no package.json but there is index.html it does npx serve

If nothing is found it just adds message that standard ways to run project were not found and proposes to send request to AI to analyse how to run the project.